### PR TITLE
Fix RequestMatcher failure_message bug

### DIFF
--- a/lib/dalziel.rb
+++ b/lib/dalziel.rb
@@ -147,7 +147,7 @@ module Dalziel
       end
 
       def failure_message
-        if @request == []
+        if @request.blank?
           "No request matched"
         elsif !@is_json
           "Accept header is not JSON.\n\n%s\n\nAccept is %s" % [ show_request, @accept.inspect ]

--- a/lib/dalziel.rb
+++ b/lib/dalziel.rb
@@ -147,7 +147,7 @@ module Dalziel
       end
 
       def failure_message
-        if @request.blank?
+        if @request.nil? || @request.empty?
           "No request matched"
         elsif !@is_json
           "Accept header is not JSON.\n\n%s\n\nAccept is %s" % [ show_request, @accept.inspect ]


### PR DESCRIPTION
In RequestMatcher, [`@request` is set to `nil`](fix-request-matcher-failure-message-bug), but then `failure_message` compares it to an empty array.  As a result the proper message isn't returned and then an error is raised from `show_request` when trying to call `.headers`.